### PR TITLE
Change UIStatusBarStyle if needed

### DIFF
--- a/BugshotKit/BSKMainViewController.m
+++ b/BugshotKit/BSKMainViewController.m
@@ -267,7 +267,7 @@ static UIImage *rotateIfNeeded(UIImage *src, UIImageOrientation orientation);
 - (void)cancelButtonTapped:(id)sender
 {
     if(self.initialStatusBarStyle != UIStatusBarStyleDefault) {
-        [[UIApplication sharedApplication] setStatusBarStyle:self.initialStatusBarStyle];
+        [[UIApplication sharedApplication] setStatusBarStyle:(UIStatusBarStyle)self.initialStatusBarStyle];
     }
     [self.navigationController.presentingViewController dismissViewControllerAnimated:YES completion:^{
         if (self.delegate) [self.delegate mainViewControllerDidClose:self];


### PR DESCRIPTION
When you have a dark `barTintColor` and therefore set the `setStatusBarStyle` to `UIStatusBarStyleLightContent`, you can now read the status bar when in Bugshot.
