### PR TITLE
Added a static library build process for conditional linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ DerivedData
 
 #CocoaPods
 Pods
+
+/BugshotKit.xcodeproj/project.xcworkspace/

--- a/BugshotKit.xcodeproj/project.pbxproj
+++ b/BugshotKit.xcodeproj/project.pbxproj
@@ -1,0 +1,370 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4C15DA34188F48E400767C78 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C15DA33188F48E400767C78 /* Foundation.framework */; };
+		4C15DA3A188F48E400767C78 /* BugshotKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA39188F48E400767C78 /* BugshotKit.m */; };
+		4C15DA59188F491000767C78 /* BSKAnnotationArrowView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA41188F491000767C78 /* BSKAnnotationArrowView.m */; };
+		4C15DA5B188F491000767C78 /* BSKAnnotationBlurView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA43188F491000767C78 /* BSKAnnotationBlurView.m */; };
+		4C15DA5D188F491000767C78 /* BSKAnnotationBoxView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA45188F491000767C78 /* BSKAnnotationBoxView.m */; };
+		4C15DA5F188F491000767C78 /* BSKAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA47188F491000767C78 /* BSKAnnotationView.m */; };
+		4C15DA61188F491000767C78 /* BSKCheckerboardView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA49188F491000767C78 /* BSKCheckerboardView.m */; };
+		4C15DA63188F491000767C78 /* BSKLogViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA4B188F491000767C78 /* BSKLogViewController.m */; };
+		4C15DA64188F491000767C78 /* BSKMainViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C15DA4C188F491000767C78 /* BSKMainViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C15DA65188F491000767C78 /* BSKMainViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA4D188F491000767C78 /* BSKMainViewController.m */; };
+		4C15DA67188F491000767C78 /* BSKNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA4F188F491000767C78 /* BSKNavigationController.m */; };
+		4C15DA69188F491000767C78 /* BSKScreenshotViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA51188F491000767C78 /* BSKScreenshotViewController.m */; };
+		4C15DA6B188F491000767C78 /* BSKToggleButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA53188F491000767C78 /* BSKToggleButton.m */; };
+		4C15DA6D188F491000767C78 /* BSKWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA55188F491000767C78 /* BSKWindow.m */; };
+		4C15DA6F188F491000767C78 /* UIImage+ImageEffects.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C15DA57188F491000767C78 /* UIImage+ImageEffects.m */; };
+		4C15DA70188F49AB00767C78 /* BugshotKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C15DA38188F48E400767C78 /* BugshotKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		4C15DA30188F48E400767C78 /* libBugshotKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBugshotKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C15DA33188F48E400767C78 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		4C15DA37188F48E400767C78 /* BugshotKit-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugshotKit-Prefix.pch"; sourceTree = "<group>"; };
+		4C15DA38188F48E400767C78 /* BugshotKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugshotKit.h; sourceTree = "<group>"; };
+		4C15DA39188F48E400767C78 /* BugshotKit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugshotKit.m; sourceTree = "<group>"; };
+		4C15DA40188F491000767C78 /* BSKAnnotationArrowView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSKAnnotationArrowView.h; sourceTree = "<group>"; };
+		4C15DA41188F491000767C78 /* BSKAnnotationArrowView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSKAnnotationArrowView.m; sourceTree = "<group>"; };
+		4C15DA42188F491000767C78 /* BSKAnnotationBlurView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSKAnnotationBlurView.h; sourceTree = "<group>"; };
+		4C15DA43188F491000767C78 /* BSKAnnotationBlurView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSKAnnotationBlurView.m; sourceTree = "<group>"; };
+		4C15DA44188F491000767C78 /* BSKAnnotationBoxView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSKAnnotationBoxView.h; sourceTree = "<group>"; };
+		4C15DA45188F491000767C78 /* BSKAnnotationBoxView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSKAnnotationBoxView.m; sourceTree = "<group>"; };
+		4C15DA46188F491000767C78 /* BSKAnnotationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSKAnnotationView.h; sourceTree = "<group>"; };
+		4C15DA47188F491000767C78 /* BSKAnnotationView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSKAnnotationView.m; sourceTree = "<group>"; };
+		4C15DA48188F491000767C78 /* BSKCheckerboardView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSKCheckerboardView.h; sourceTree = "<group>"; };
+		4C15DA49188F491000767C78 /* BSKCheckerboardView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSKCheckerboardView.m; sourceTree = "<group>"; };
+		4C15DA4A188F491000767C78 /* BSKLogViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSKLogViewController.h; sourceTree = "<group>"; };
+		4C15DA4B188F491000767C78 /* BSKLogViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSKLogViewController.m; sourceTree = "<group>"; };
+		4C15DA4C188F491000767C78 /* BSKMainViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSKMainViewController.h; sourceTree = "<group>"; };
+		4C15DA4D188F491000767C78 /* BSKMainViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSKMainViewController.m; sourceTree = "<group>"; };
+		4C15DA4E188F491000767C78 /* BSKNavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSKNavigationController.h; sourceTree = "<group>"; };
+		4C15DA4F188F491000767C78 /* BSKNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSKNavigationController.m; sourceTree = "<group>"; };
+		4C15DA50188F491000767C78 /* BSKScreenshotViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSKScreenshotViewController.h; sourceTree = "<group>"; };
+		4C15DA51188F491000767C78 /* BSKScreenshotViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSKScreenshotViewController.m; sourceTree = "<group>"; };
+		4C15DA52188F491000767C78 /* BSKToggleButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSKToggleButton.h; sourceTree = "<group>"; };
+		4C15DA53188F491000767C78 /* BSKToggleButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSKToggleButton.m; sourceTree = "<group>"; };
+		4C15DA54188F491000767C78 /* BSKWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSKWindow.h; sourceTree = "<group>"; };
+		4C15DA55188F491000767C78 /* BSKWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSKWindow.m; sourceTree = "<group>"; };
+		4C15DA56188F491000767C78 /* UIImage+ImageEffects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+ImageEffects.h"; sourceTree = "<group>"; };
+		4C15DA57188F491000767C78 /* UIImage+ImageEffects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+ImageEffects.m"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4C15DA2C188F48E400767C78 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C15DA34188F48E400767C78 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4C15DA25188F48E300767C78 = {
+			isa = PBXGroup;
+			children = (
+				4C15DA35188F48E400767C78 /* BugshotKit */,
+				4C15DA32188F48E400767C78 /* Frameworks */,
+				4C15DA31188F48E400767C78 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		4C15DA31188F48E400767C78 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4C15DA30188F48E400767C78 /* libBugshotKit.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4C15DA32188F48E400767C78 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				4C15DA33188F48E400767C78 /* Foundation.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4C15DA35188F48E400767C78 /* BugshotKit */ = {
+			isa = PBXGroup;
+			children = (
+				4C15DA38188F48E400767C78 /* BugshotKit.h */,
+				4C15DA39188F48E400767C78 /* BugshotKit.m */,
+				4C15DA40188F491000767C78 /* BSKAnnotationArrowView.h */,
+				4C15DA41188F491000767C78 /* BSKAnnotationArrowView.m */,
+				4C15DA42188F491000767C78 /* BSKAnnotationBlurView.h */,
+				4C15DA43188F491000767C78 /* BSKAnnotationBlurView.m */,
+				4C15DA44188F491000767C78 /* BSKAnnotationBoxView.h */,
+				4C15DA45188F491000767C78 /* BSKAnnotationBoxView.m */,
+				4C15DA46188F491000767C78 /* BSKAnnotationView.h */,
+				4C15DA47188F491000767C78 /* BSKAnnotationView.m */,
+				4C15DA48188F491000767C78 /* BSKCheckerboardView.h */,
+				4C15DA49188F491000767C78 /* BSKCheckerboardView.m */,
+				4C15DA4A188F491000767C78 /* BSKLogViewController.h */,
+				4C15DA4B188F491000767C78 /* BSKLogViewController.m */,
+				4C15DA4C188F491000767C78 /* BSKMainViewController.h */,
+				4C15DA4D188F491000767C78 /* BSKMainViewController.m */,
+				4C15DA4E188F491000767C78 /* BSKNavigationController.h */,
+				4C15DA4F188F491000767C78 /* BSKNavigationController.m */,
+				4C15DA50188F491000767C78 /* BSKScreenshotViewController.h */,
+				4C15DA51188F491000767C78 /* BSKScreenshotViewController.m */,
+				4C15DA52188F491000767C78 /* BSKToggleButton.h */,
+				4C15DA53188F491000767C78 /* BSKToggleButton.m */,
+				4C15DA54188F491000767C78 /* BSKWindow.h */,
+				4C15DA55188F491000767C78 /* BSKWindow.m */,
+				4C15DA56188F491000767C78 /* UIImage+ImageEffects.h */,
+				4C15DA57188F491000767C78 /* UIImage+ImageEffects.m */,
+				4C15DA36188F48E400767C78 /* Supporting Files */,
+			);
+			path = BugshotKit;
+			sourceTree = "<group>";
+		};
+		4C15DA36188F48E400767C78 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				4C15DA37188F48E400767C78 /* BugshotKit-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		4C15DA2D188F48E400767C78 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C15DA70188F49AB00767C78 /* BugshotKit.h in Headers */,
+				4C15DA64188F491000767C78 /* BSKMainViewController.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		4C15DA2F188F48E400767C78 /* BugshotKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4C15DA3D188F48E400767C78 /* Build configuration list for PBXNativeTarget "BugshotKit" */;
+			buildPhases = (
+				4C15DA2A188F48E400767C78 /* ShellScript */,
+				4C15DA2B188F48E400767C78 /* Sources */,
+				4C15DA2C188F48E400767C78 /* Frameworks */,
+				4C15DA2D188F48E400767C78 /* Headers */,
+				4C15DA2E188F48E400767C78 /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BugshotKit;
+			productName = BugshotKit;
+			productReference = 4C15DA30188F48E400767C78 /* libBugshotKit.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4C15DA26188F48E300767C78 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0500;
+				ORGANIZATIONNAME = "Marco Arment";
+			};
+			buildConfigurationList = 4C15DA29188F48E300767C78 /* Build configuration list for PBXProject "BugshotKit" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 4C15DA25188F48E300767C78;
+			productRefGroup = 4C15DA31188F48E400767C78 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4C15DA2F188F48E400767C78 /* BugshotKit */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		4C15DA2A188F48E400767C78 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\n\nif [ \"$CALLED_FROM_MASTER\" ]\nthen\n# This is the other build, called from the original instance\nexit 0\nfi\n\n# Clean up prior to build\n\nCURRENTCONFIG_DEVICE_DIR=\"${SYMROOT}/${CONFIGURATION}-iphoneos\"\nCURRENTCONFIG_SIMULATOR_DIR=\"${SYMROOT}/${CONFIGURATION}-iphonesimulator\"\nCURRENTCONFIG_UNIVERSAL_DIR=\"${SYMROOT}/${CONFIGURATION}-universal\"\n\nif [ ! -f \"${CURRENTCONFIG_DEVICE_DIR}/${EXECUTABLE_NAME}\" ]; then\n  echo \"Device build cleaned; cleaning other builds too\"\n  rm -f \"${CURRENTCONFIG_SIMULATOR_DIR}/${EXECUTABLE_NAME}\" \n  rm -f \"${CURRENTCONFIG_UNIVERSAL_DIR}/${EXECUTABLE_NAME}\"\nelif [ ! -f \"${CURRENTCONFIG_SIMULATOR_DIR}/${EXECUTABLE_NAME}\" ]; then\n  echo \"Simulator build cleaned; cleaning other builds too\"\n  rm -f \"${CURRENTCONFIG_DEVICE_DIR}/${EXECUTABLE_NAME}\"\n  rm -f \"${CURRENTCONFIG_UNIVERSAL_DIR}/${EXECUTABLE_NAME}\"\nfi\n";
+		};
+		4C15DA2E188F48E400767C78 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\n\n#\n# Universal static library script\n# http://github.com/michaeltyson/iOS-Universal-Library-Template\n#\n# Version 2.5\n#\n# Purpose:\n#   Create a static library for iPhone from within XCode\n#\n# Author: Adam Martin - http://twitter.com/redglassesapps\n# Tweaked and made into an Xcode template by Michael Tyson - http://atastypixel.com/blog\n# Based on original script from Eonil\n# More info: see this Stack Overflow question: http://stackoverflow.com/questions/3520977/build-fat-static-library-device-simulator-using-xcode-and-sdk-4\n# Additional changes by John Lawson <http://jelawson.com> to copy the CURRENTCONFIG_DEVICE_DIR to the CURRENTCONFIG_UNIVERSAL_DIR instead of creating it\n# to include other files that might have been copied via Copy Files build phases (e.g. readme files, xibs, etc); this removes the need to copy just\n# the header folder.\n#\n#################[ Tests: helps workaround any future bugs in Xcode ]########\n#\nDEBUG_THIS_SCRIPT=\"true\"\n\nif [ $DEBUG_THIS_SCRIPT = \"true\" ]\nthen\necho \"########### TESTS #############\"\necho \"Use the following variables when debugging this script; note that they may change on recursions\"\necho \"BUILD_DIR = $BUILD_DIR\"\necho \"BUILD_ROOT = $BUILD_ROOT\"\necho \"CONFIGURATION_BUILD_DIR = $CONFIGURATION_BUILD_DIR\"\necho \"BUILT_PRODUCTS_DIR = $BUILT_PRODUCTS_DIR\"\necho \"CONFIGURATION_TEMP_DIR = $CONFIGURATION_TEMP_DIR\"\necho \"TARGET_BUILD_DIR = $TARGET_BUILD_DIR\"\nfi\n\nif [ \"$CALLED_FROM_MASTER\" ]\nthen\n# This is the other build, called from the original instance\nexit 0\nfi\n\n# Find the BASESDK version number\nSDK_VERSION=$(echo ${SDK_NAME} | grep -o '.\\{3\\}$')\n\n# Next, work out if we're in SIM or DEVICE\nif [ ${PLATFORM_NAME} = \"iphonesimulator\" ]\nthen\nOTHER_SDK_TO_BUILD=iphoneos${SDK_VERSION}\nelse\nOTHER_SDK_TO_BUILD=iphonesimulator${SDK_VERSION}\nfi\n\necho \"XCode has selected SDK: ${PLATFORM_NAME} with version: ${SDK_VERSION} (although back-targetting: ${IPHONEOS_DEPLOYMENT_TARGET})\"\necho \"...therefore, OTHER_SDK_TO_BUILD = ${OTHER_SDK_TO_BUILD}\"\n\n# Build the other architecture\necho \"xcodebuild -project \\\"${PROJECT_FILE_PATH}\\\" -configuration \\\"${CONFIGURATION}\\\" -target \\\"${TARGET_NAME}\\\" -sdk \\\"${OTHER_SDK_TO_BUILD}\\\" ${ACTION} RUN_CLANG_STATIC_ANALYZER=NO BUILD_DIR=\\\"${BUILD_DIR}\\\" BUILD_ROOT=\\\"${BUILD_ROOT}\\\" CALLED_FROM_MASTER=1\"\nxcodebuild -project \"${PROJECT_FILE_PATH}\" -configuration \"${CONFIGURATION}\" -target \"${TARGET_NAME}\" -sdk \"${OTHER_SDK_TO_BUILD}\" ${ACTION} RUN_CLANG_STATIC_ANALYZER=NO BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\" CALLED_FROM_MASTER=1\n\n# Merge built architectures\nCURRENTCONFIG_DEVICE_DIR=\"${SYMROOT}/${CONFIGURATION}-iphoneos\"\nCURRENTCONFIG_SIMULATOR_DIR=\"${SYMROOT}/${CONFIGURATION}-iphonesimulator\"\nCURRENTCONFIG_UNIVERSAL_DIR=\"${SYMROOT}/${CONFIGURATION}-universal\"\n\necho \"Taking device build from: ${CURRENTCONFIG_DEVICE_DIR}\"\necho \"Taking simulator build from: ${CURRENTCONFIG_SIMULATOR_DIR}\"\necho \"...I will output a universal build to: ${CURRENTCONFIG_UNIVERSAL_DIR}\"\n\nif [ ! -e \"${CURRENTCONFIG_UNIVERSAL_DIR}/${EXECUTABLE_NAME}\" -o \\\n\"${CURRENTCONFIG_DEVICE_DIR}/${EXECUTABLE_NAME}\" -nt \"${CURRENTCONFIG_UNIVERSAL_DIR}/${EXECUTABLE_NAME}\" -o \\\n\"${CURRENTCONFIG_SIMULATOR_DIR}/${EXECUTABLE_NAME}\" -nt \"${CURRENTCONFIG_UNIVERSAL_DIR}/${EXECUTABLE_NAME}\" ]\nthen\nrm -rf \"${CURRENTCONFIG_UNIVERSAL_DIR}\"\ncp -R \"${CURRENTCONFIG_DEVICE_DIR}\" \"${CURRENTCONFIG_UNIVERSAL_DIR}\"\nrm -f \"${CURRENTCONFIG_UNIVERSAL_DIR}/${EXECUTABLE_NAME}\"\n\necho \"lipo: for current configuration (${CONFIGURATION}) creating output file: ${CURRENTCONFIG_UNIVERSAL_DIR}/${EXECUTABLE_NAME}\"\nlipo -create -output \"${CURRENTCONFIG_UNIVERSAL_DIR}/${EXECUTABLE_NAME}\" \"${CURRENTCONFIG_DEVICE_DIR}/${EXECUTABLE_NAME}\" \"${CURRENTCONFIG_SIMULATOR_DIR}/${EXECUTABLE_NAME}\"\n\necho \"Copying universal build back over to ${CURRENTCONFIG_DEVICE_DIR} and ${CURRENTCONFIG_SIMULATOR_DIR}\"\ncp \"${CURRENTCONFIG_UNIVERSAL_DIR}/${EXECUTABLE_NAME}\" \"${CURRENTCONFIG_DEVICE_DIR}/${EXECUTABLE_NAME}\"\ncp \"${CURRENTCONFIG_UNIVERSAL_DIR}/${EXECUTABLE_NAME}\" \"${CURRENTCONFIG_SIMULATOR_DIR}/${EXECUTABLE_NAME}\"\ntouch \"${CURRENTCONFIG_UNIVERSAL_DIR}/${EXECUTABLE_NAME}\"\n\nelse\necho \"Everything up to date.\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4C15DA2B188F48E400767C78 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C15DA61188F491000767C78 /* BSKCheckerboardView.m in Sources */,
+				4C15DA6F188F491000767C78 /* UIImage+ImageEffects.m in Sources */,
+				4C15DA5F188F491000767C78 /* BSKAnnotationView.m in Sources */,
+				4C15DA6D188F491000767C78 /* BSKWindow.m in Sources */,
+				4C15DA5D188F491000767C78 /* BSKAnnotationBoxView.m in Sources */,
+				4C15DA6B188F491000767C78 /* BSKToggleButton.m in Sources */,
+				4C15DA63188F491000767C78 /* BSKLogViewController.m in Sources */,
+				4C15DA59188F491000767C78 /* BSKAnnotationArrowView.m in Sources */,
+				4C15DA5B188F491000767C78 /* BSKAnnotationBlurView.m in Sources */,
+				4C15DA65188F491000767C78 /* BSKMainViewController.m in Sources */,
+				4C15DA69188F491000767C78 /* BSKScreenshotViewController.m in Sources */,
+				4C15DA67188F491000767C78 /* BSKNavigationController.m in Sources */,
+				4C15DA3A188F48E400767C78 /* BugshotKit.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		4C15DA3B188F48E400767C78 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		4C15DA3C188F48E400767C78 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		4C15DA3E188F48E400767C78 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DSTROOT = /tmp/BugshotKit.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BugshotKit/BugshotKit-Prefix.pch";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		4C15DA3F188F48E400767C78 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DSTROOT = /tmp/BugshotKit.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BugshotKit/BugshotKit-Prefix.pch";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4C15DA29188F48E300767C78 /* Build configuration list for PBXProject "BugshotKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4C15DA3B188F48E400767C78 /* Debug */,
+				4C15DA3C188F48E400767C78 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4C15DA3D188F48E400767C78 /* Build configuration list for PBXNativeTarget "BugshotKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4C15DA3E188F48E400767C78 /* Debug */,
+				4C15DA3F188F48E400767C78 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4C15DA26188F48E300767C78 /* Project object */;
+}

--- a/BugshotKit/BugshotKit-Prefix.pch
+++ b/BugshotKit/BugshotKit-Prefix.pch
@@ -1,0 +1,9 @@
+//
+//  Prefix header
+//
+//  The contents of this file are implicitly included at the beginning of every source file.
+//
+
+#ifdef __OBJC__
+    #import <Foundation/Foundation.h>
+#endif

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ To help prevent accidentally shipping your app with BugshotKit, I've included a 
 
 These safeguards aren't guaranteed. Please don't rely on them. Remove BugshotKit from your App Store builds.
 
+## Setup
+
+The easiest way to be sure you're not going to build BugshotKit into your App Store builds is to link to it just in your Debug and Ad-Hoc builds. To do that:
+
+1. Build a static library from the BugshotKit Xcode project.
+2. Put that library, and the header files that come with it, somewhere in your project folder.
+3. Make sure your app build settings' Library Search Paths and Header Search Paths include the path to where you put these.
+4. Add `-lBugshotKit` to the Other Linker Flags setting, but only for the Debug and Ad-Hoc builds.
+5. Use a conditional macro (e.g. "`#ifdef DEBUG`"..."`#endif`") around the BugshotKit import and the invocation, below.
+
 ## Usage
 
 Simply invoke `[BugshotKit enableWithNumberOfTouches:...]` from your `application:didFinishLaunchingWithOptions:`:


### PR DESCRIPTION
I've added an Xcode project which will build a universal static library (based on [this template](https://github.com/michaeltyson/iOS-Universal-Library-Template)), so one can use a conditional linker flag to only link to BugshotKit from Debug/Ad-Hoc builds. That way, no BugshotKit symbols will be present in an App Store build. Instructions added to the Readme.
