### PR TITLE
Address compiler warnings when used with non-ARC apps

### DIFF
--- a/BugshotKit/BugshotKit.h
+++ b/BugshotKit/BugshotKit.h
@@ -70,16 +70,16 @@ typedef enum : NSUInteger {
 
 - (NSString *)currentConsoleLogWithDateStamps:(BOOL)dateStamps;
 
-@property (nonatomic) UIColor *annotationFillColor;
-@property (nonatomic) UIColor *annotationStrokeColor;
-@property (nonatomic) UIColor *toggleOnColor;
-@property (nonatomic) UIColor *toggleOffColor;
+@property (nonatomic, strong) UIColor *annotationFillColor;
+@property (nonatomic, strong) UIColor *annotationStrokeColor;
+@property (nonatomic, strong) UIColor *toggleOnColor;
+@property (nonatomic, strong) UIColor *toggleOffColor;
 
 
 // don't mess with these
-@property (nonatomic) UIImage *snapshotImage;
+@property (nonatomic, strong) UIImage *snapshotImage;
 @property (nonatomic, copy) NSArray *annotations;
-@property (nonatomic) UIImage *annotatedImage;
+@property (nonatomic, strong) UIImage *annotatedImage;
 @property (nonatomic, copy) NSDictionary *(^extraInfoBlock)();
 @property (nonatomic, copy) NSString *(^emailSubjectBlock)(NSDictionary *info);
 


### PR DESCRIPTION
If you're interested, this adds explicit 'strong' @property modifiers to the main header, to avoid some complier warnings when used with non-ARC apps.
