### PR TITLE
Allow user to confirm their design to bring up BugshotKit UI.

### DIFF
--- a/BugshotKit/BugshotKit.h
+++ b/BugshotKit/BugshotKit.h
@@ -41,6 +41,7 @@ typedef enum : NSUInteger {
 + (void)addLogMessage:(NSString *)message;
 + (UIFont *)consoleFontWithSize:(CGFloat)size;
 
+@property (nonatomic, strong) void(^confirmationBlock)(void (^confirmedBlock)(BOOL shouldShow));
 @property (nonatomic, copy) NSString *destinationEmailAddress;
 @property (nonatomic) NSUInteger consoleLogMaxLines;
 

--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -38,6 +38,7 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
     dispatch_source_t source;
 }
 @property (nonatomic) BOOL isShowing;
+@property (nonatomic) BOOL isConfirming;
 @property (nonatomic) BOOL isDisabled;
 @property (nonatomic, weak) UIWindow *window;
 @property (nonatomic) NSMapTable *windowsWithGesturesAttached;
@@ -350,6 +351,23 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
 }
 
 - (void)handleOpenGesture:(UIGestureRecognizer *)sender
+{
+    if (self.confirmationBlock) {
+        if (self.isConfirming) return;
+        self.isConfirming = YES;
+        self.confirmationBlock(^(BOOL shouldShow){
+            self.isConfirming = NO;
+            if (shouldShow) {
+                [self handleOpenGesturePostConfirmation:sender];
+            }
+        });
+    }
+    else {
+        [self handleOpenGesturePostConfirmation:sender];
+    }
+}
+
+- (void)handleOpenGesturePostConfirmation:(UIGestureRecognizer *)sender
 {
     if (self.isShowing) return;
 


### PR DESCRIPTION
We've found, particularly with the shake gesture, that users get confused by the BugshotKit UI. They don't know what they did to induce it, and some of them don't know what it is for.

This pull request adds the optional ability for the application to confirm with the user their intent to bring up the UI.

It also provides a opportunity to teach the user what BugshotKit is for. In our case, we put up a simple alert that says something like "**Would you like to report a bug or provide feedback? Yes/No**". If they shook the phone by mistake, the user now understands what happened. Plus, they now know what to do in the future if they do want to report a bug.

Here's our application code that uses this feature.

``` objective-c
BugshotKit.sharedManager.confirmationBlock = ^(void (^confirmedBlock)(BOOL shouldShow)) {
  [UIAlertView alertViewWithTitle:nil
                          message:@"Would you like to report a bug or provide feedback?"
                cancelButtonTitle:@"No"
                otherButtonTitles:@[@"Yes"]
                        onDismiss:^(int buttonIndex) {
                            confirmedBlock(YES);
                        }
                         onCancel:^{
                             confirmedBlock(NO);
                         }];
  };
```
