### PR TITLE
Add ability to define a block which allows user to customize the MFMailComposeViewController

### DIFF
--- a/BugshotKit/BSKMainViewController.m
+++ b/BugshotKit/BSKMainViewController.m
@@ -326,7 +326,8 @@ static UIImage *rotateIfNeeded(UIImage *src);
     if (screenshot) [mf addAttachmentData:UIImagePNGRepresentation(rotateIfNeeded(screenshot)) mimeType:@"image/png" fileName:@"screenshot.png"];
     if (log) [mf addAttachmentData:[log dataUsingEncoding:NSUTF8StringEncoding] mimeType:@"text/plain" fileName:@"log.txt"];
     if (userInfoJSON) [mf addAttachmentData:userInfoJSON mimeType:@"application/json" fileName:@"info.json"];
-
+    if(BugshotKit.sharedManager.mailComposeCustomizeBlock) BugshotKit.sharedManager.mailComposeCustomizeBlock(mf);
+    
     mf.mailComposeDelegate = self;
     [self presentViewController:mf animated:YES completion:NULL];
 }

--- a/BugshotKit/BugshotKit.h
+++ b/BugshotKit/BugshotKit.h
@@ -73,6 +73,12 @@ typedef enum : NSUInteger {
  */
 + (void)setEmailBodyBlock:(NSString *(^)(NSDictionary *))emailBodyBlock;
 
+/*
+ You can optionally customize the mail compose view controller by setting an mailComposeCustomizeBlock.
+ 
+ Use this block e.g. for adding file attachments to the e-mail being sent.
+ */
++ (void)setMailComposeCustomizeBlock:(void (^)(MFMailComposeViewController *mailComposer))mailComposeCustomizeBlock;
 
 // feel free to mess with these if you want
 
@@ -94,6 +100,7 @@ typedef enum : NSUInteger {
 @property (nonatomic, copy) NSArray *annotations;
 @property (nonatomic, strong) UIImage *annotatedImage;
 @property (nonatomic, copy) NSDictionary *(^extraInfoBlock)();
+@property (nonatomic, copy) void (^mailComposeCustomizeBlock)(MFMailComposeViewController *mailComposer);
 @property (nonatomic, copy) NSString *(^emailSubjectBlock)(NSDictionary *info);
 @property (nonatomic, copy) NSString *(^emailBodyBlock)(NSDictionary *info);
 

--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -100,6 +100,11 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
     BugshotKit.sharedManager.emailBodyBlock = emailBodyBlock;
 }
 
++ (void)setMailComposeCustomizeBlock:(void (^)(MFMailComposeViewController *mailComposer))mailComposeCustomizeBlock
+{
+    BugshotKit.sharedManager.mailComposeCustomizeBlock = mailComposeCustomizeBlock;
+}
+
 + (UIFont *)consoleFontWithSize:(CGFloat)size
 {
     static dispatch_once_t onceToken;


### PR DESCRIPTION
My use case:  Add custom file attachments to the e-mail sent by Bugshot.
