### PR TITLE
Added missing [super viewWillDisappear:animated]

### DIFF
--- a/BugshotKit/BSKScreenshotViewController.m
+++ b/BugshotKit/BSKScreenshotViewController.m
@@ -156,6 +156,8 @@
 
     BugshotKit.sharedManager.annotations = savedAnnotations;
     BugshotKit.sharedManager.annotatedImage = annotatedImage;
+
+    [super viewWillDisappear:animated];    
 }
 
 - (void)contentAreaTapped:(UITapGestureRecognizer *)sender


### PR DESCRIPTION
Missing call to super causes clang static analysis warnings with the latest Xcode6 beta.
