### PR TITLE
Null pointer exception in logging method

### DIFF
--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -526,7 +526,10 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
         foundNewEntries = YES;
         
         NSTimeInterval msgTime = (NSTimeInterval) atol(asl_get(m, ASL_KEY_TIME)) + ((NSTimeInterval) atol(asl_get(m, ASL_KEY_TIME_NSEC)) / 1000000000.0);
-        [self addLogMessage:[NSString stringWithUTF8String:asl_get(m, ASL_KEY_MSG)] timestamp:msgTime];
+
+        const char *msg = asl_get(m, ASL_KEY_MSG);
+        if (msg == NULL) { continue; }
+        [self addLogMessage:[NSString stringWithUTF8String:msg] timestamp:msgTime];
     }
     
     aslresponse_free(r);


### PR DESCRIPTION
Using iOS 8 SDK an exception was being raised while preparing the log data. This is a sanity check on the asl_get() result before passing the value to the NSString class method.
