### PR TITLE
Adding a text display mode to the log viewer

### DIFF
--- a/BugshotKit/BSKLogViewController.m
+++ b/BugshotKit/BSKLogViewController.m
@@ -7,6 +7,7 @@
 
 @interface BSKLogViewController ()
 @property (nonatomic) UIImageView *consoleView;
+@property (nonatomic) UITextView *consoleTextView;
 @end
 
 static int markerNumber = 0;
@@ -33,8 +34,9 @@ static int markerNumber = 0;
 {
     [super viewDidLoad];
 
-    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|[c]|" options:0 metrics:nil views:@{ @"c" : self.consoleView }]];
-    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[top][c]|" options:0 metrics:nil views:@{ @"c" : self.consoleView, @"top" : self.topLayoutGuide }]];
+    UIView *console = ([BugshotKit.sharedManager displayConsoleTextInLogViewer] ? self.consoleTextView : self.consoleView);
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|[c]|" options:0 metrics:nil views:@{ @"c" : console }]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[top][c]|" options:0 metrics:nil views:@{ @"c" : console, @"top" : self.topLayoutGuide }]];
 
     dispatch_async(dispatch_get_main_queue(), ^{ [self updateLiveLog:nil]; });
 }
@@ -51,20 +53,40 @@ static int markerNumber = 0;
     UIView *view = [[UIView alloc] initWithFrame:frame];
     view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     view.autoresizesSubviews = YES;
-    
-    self.consoleView = [[UIImageView alloc] initWithFrame:frame];
-    self.consoleView.translatesAutoresizingMaskIntoConstraints = NO;
-    [view addSubview:self.consoleView];
-    
+
+    if ([BugshotKit.sharedManager displayConsoleTextInLogViewer]) {
+        self.automaticallyAdjustsScrollViewInsets = NO;
+        self.consoleTextView = [[UITextView alloc] initWithFrame:frame];
+        self.consoleTextView.translatesAutoresizingMaskIntoConstraints = NO;
+        self.consoleTextView.editable = NO;
+        self.consoleTextView.font = [BugshotKit consoleFontWithSize:(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? 13.0f : 9.0f)];
+        [view addSubview:self.consoleTextView];
+    }
+    else {
+        self.consoleView = [[UIImageView alloc] initWithFrame:frame];
+        self.consoleView.translatesAutoresizingMaskIntoConstraints = NO;
+        [view addSubview:self.consoleView];
+    }
+
     self.view = view;
 }
 
 - (void)updateLiveLog:(NSNotification *)n
 {
     if (! self.isViewLoaded) return;
-    [BugshotKit.sharedManager consoleImageWithSize:self.consoleView.bounds.size fontSize:(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? 13.0f : 9.0f) emptyBottomLine:YES withCompletion:^(UIImage *image) {
-        self.consoleView.image = image;
-    }];
+
+    if ([BugshotKit.sharedManager displayConsoleTextInLogViewer]) {
+        [BugshotKit.sharedManager currentConsoleLogWithDateStamps:YES
+                                                   withCompletion:^(NSString *result) {
+                                                       self.consoleTextView.text = result;
+                                                       [self.consoleTextView scrollRangeToVisible:NSMakeRange([result length], 0)];
+                                                   }];
+    }
+    else {
+        [BugshotKit.sharedManager consoleImageWithSize:self.consoleView.bounds.size fontSize:(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? 13.0f : 9.0f) emptyBottomLine:YES withCompletion:^(UIImage *image) {
+            self.consoleView.image = image;
+        }];
+    }
 }
 
 

--- a/BugshotKit/BugshotKit.h
+++ b/BugshotKit/BugshotKit.h
@@ -81,6 +81,13 @@ typedef enum : NSUInteger {
  */
 + (void)setMailComposeCustomizeBlock:(void (^)(MFMailComposeViewController *mailComposer))mailComposeCustomizeBlock;
 
+/*
+ You can display the console log viewer as selectable text. Defaults to NO which presents a screenshot of the log text.
+
+ @param displayText YES if the console log should be displayed as selectable text. NO if it should use a screenshot.
+ */
++ (void)setDisplayConsoleTextInLogViewer:(BOOL)displayText;
+
 // feel free to mess with these if you want
 
 - (void)currentConsoleLogWithDateStamps:(BOOL)dateStamps
@@ -90,6 +97,8 @@ typedef enum : NSUInteger {
              emptyBottomLine:(BOOL)emptyBottomLine
               withCompletion:(void (^)(UIImage *result))completion;
 
+
+@property (nonatomic) BOOL displayConsoleTextInLogViewer;
 @property (nonatomic, strong) UIColor *annotationFillColor;
 @property (nonatomic, strong) UIColor *annotationStrokeColor;
 @property (nonatomic, strong) UIColor *toggleOnColor;

--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -106,6 +106,11 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
     BugshotKit.sharedManager.mailComposeCustomizeBlock = mailComposeCustomizeBlock;
 }
 
++ (void)setDisplayConsoleTextInLogViewer:(BOOL)displayText
+{
+    BugshotKit.sharedManager.displayConsoleTextInLogViewer = displayText;
+}
+
 + (UIFont *)consoleFontWithSize:(CGFloat)size
 {
     static dispatch_once_t onceToken;


### PR DESCRIPTION
I've had experiences where it would be helpful to scroll back or select text directly in the console log viewer. This pull request adds a mode (off by default) to replace the console screenshot with a text view.
