### PR TITLE
Fix deprecations in iOS 8

### DIFF
--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -521,7 +521,7 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
     aslresponse r = asl_search(NULL, q);
     BOOL foundNewEntries = NO;
     
-    while ( (m = aslresponse_next(r)) ) {
+    while ( (m = asl_next(r)) ) {
         if (myPID != atol(asl_get(m, ASL_KEY_PID))) continue;
 
         // dupe checking
@@ -537,7 +537,7 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
         [self addLogMessage:[NSString stringWithUTF8String:msg] timestamp:msgTime];
     }
     
-    aslresponse_free(r);
+    asl_release(r);
     asl_free(q);
 
     return foundNewEntries;


### PR DESCRIPTION
Two little changes. In both cases the replacement methods are documented as being identical.
`aslresponse_next()` is deprecated in favour of `asl_next()`
`aslresponse_free()` is deprecated in favour of `aslresponse_free()`
