### PR TITLE
Fix iOS 8 functional issues and annoyances

### DIFF
--- a/BugshotKit/BSKWindow.m
+++ b/BugshotKit/BSKWindow.m
@@ -31,7 +31,7 @@
 
 - (void)applicationWillEnterForeground:(NSNotification *)n
 {
-    [BugshotKit dismissAninmated:NO completion:NULL];
+    [BugshotKit dismissAnimated:NO completion:NULL];
 }
 
 - (void)applicationDidBecomeActive:(NSNotification *)n

--- a/BugshotKit/BugshotKit.h
+++ b/BugshotKit/BugshotKit.h
@@ -34,7 +34,7 @@ typedef enum : NSUInteger {
 
 /* You can also always show it manually */
 + (void)show;
-+ (void)dismissAninmated:(BOOL)animated completion:(void(^)())completion;
++ (void)dismissAnimated:(BOOL)animated completion:(void(^)())completion;
 
 + (instancetype)sharedManager;
 - (void)clearLog;

--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -509,6 +509,14 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
     }
 }
 
+// Because aslresponse_next is now deprecated.
+asl_object_t SystemSafeASLNext(asl_object_t r) {
+    if ([UIDevice currentDevice].systemVersion.floatValue >= 8.0f) {
+        return asl_next(r);
+    }
+    return aslresponse_next(r);
+}
+
 // assumed to always be in logQueue
 - (BOOL)updateFromASL
 {
@@ -521,7 +529,7 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
     aslresponse r = asl_search(NULL, q);
     BOOL foundNewEntries = NO;
     
-    while ( (m = asl_next(r)) ) {
+    while ( (m = SystemSafeASLNext(r)) ) {
         if (myPID != atol(asl_get(m, ASL_KEY_PID))) continue;
 
         // dupe checking
@@ -537,7 +545,11 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
         [self addLogMessage:[NSString stringWithUTF8String:msg] timestamp:msgTime];
     }
     
-    asl_release(r);
+    if ([UIDevice currentDevice].systemVersion.floatValue >= 8.0f) {
+        asl_release(r);
+    } else {
+        aslresponse_free(r);
+    }
     asl_free(q);
 
     return foundNewEntries;

--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -427,8 +427,7 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
     [presentingViewController presentViewController:nc animated:YES completion:NULL];
 }
 
-+ (void)dismissAninmated:(BOOL)animated completion:(void(^)())completion
-{
++ (void)dismissAnimated:(BOOL)animated completion:(void(^)())completion {
     UIViewController *presentingVC = BugshotKit.sharedManager.presentedNavigationController.presentingViewController;
     if (presentingVC) {
         [presentingVC dismissViewControllerAnimated:animated completion:completion];

--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -514,7 +514,14 @@ asl_object_t SystemSafeASLNext(asl_object_t r) {
     if ([UIDevice currentDevice].systemVersion.floatValue >= 8.0f) {
         return asl_next(r);
     }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // The deprecation attribute incorrectly states that the replacement method, asl_next()
+    // is available in __IPHONE_7_0; asl_next() first appears in __IPHONE_8_0.
+    // This would require both a compile and runtime check to properly implement the new method
+    // while the minimum deployment target for this project remains iOS 7.0.
     return aslresponse_next(r);
+#pragma clang diagnostic pop
 }
 
 // assumed to always be in logQueue
@@ -548,7 +555,14 @@ asl_object_t SystemSafeASLNext(asl_object_t r) {
     if ([UIDevice currentDevice].systemVersion.floatValue >= 8.0f) {
         asl_release(r);
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        // The deprecation attribute incorrectly states that the replacement method, asl_release()
+        // is available in __IPHONE_7_0; asl_release() first appears in __IPHONE_8_0.
+        // This would require both a compile and runtime check to properly implement the new method
+        // while the minimum deployment target for this project remains iOS 7.0.
         aslresponse_free(r);
+#pragma clang diagnostic pop
     }
     asl_free(q);
 

--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -594,8 +594,7 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
 {
 #if TARGET_IPHONE_SIMULATOR
     return NO;
-#endif
-
+#else
     // Adapted from https://github.com/blindsightcorp/BSMobileProvision
 
     NSString *binaryMobileProvision = [NSString stringWithContentsOfFile:[NSBundle.mainBundle pathForResource:@"embedded" ofType:@"mobileprovision"] encoding:NSISOLatin1StringEncoding error:NULL];
@@ -618,6 +617,7 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
     if (mobileProvision[@"ProvisionedDevices"] && ((NSDictionary *)mobileProvision[@"ProvisionedDevices"]).count) return NO; // development or ad-hoc
 
     return YES; // expected development/enterprise/ad-hoc entitlements not found
+#endif
 }
 
 

--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -408,7 +408,7 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
     self.snapshotImage = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
 
-    if (interfaceOrientation != UIInterfaceOrientationPortrait) {
+    if ([UIDevice currentDevice].systemVersion.floatValue < 8.0f && interfaceOrientation != UIInterfaceOrientationPortrait) {
         self.snapshotImage = [[UIImage alloc] initWithCGImage:self.snapshotImage.CGImage scale:UIScreen.mainScreen.scale orientation:(
             interfaceOrientation == UIInterfaceOrientationPortraitUpsideDown ? UIImageOrientationDown : (
                 interfaceOrientation == UIInterfaceOrientationLandscapeLeft ? UIImageOrientationRight : UIImageOrientationLeft

--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -424,6 +424,7 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
     BSKNavigationController *nc = [[BSKNavigationController alloc] initWithRootViewController:mvc lockedToRotation:self.window.rootViewController.interfaceOrientation];
     self.presentedNavigationController = nc;
     nc.navigationBar.tintColor = BugshotKit.sharedManager.annotationFillColor;
+    nc.navigationBar.titleTextAttributes = @{ NSForegroundColorAttributeName:BugshotKit.sharedManager.annotationFillColor };
     [presentingViewController presentViewController:nc animated:YES completion:NULL];
 }
 

--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -521,7 +521,7 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
     aslresponse r = asl_search(NULL, q);
     BOOL foundNewEntries = NO;
     
-    while ( (m = aslresponse_next(r)) ) {
+    while ( (m = asl_next(r)) ) {
         if (myPID != atol(asl_get(m, ASL_KEY_PID))) continue;
 
         // dupe checking
@@ -537,7 +537,7 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
         [self addLogMessage:[NSString stringWithUTF8String:msg] timestamp:msgTime];
     }
     
-    aslresponse_free(r);
+    asl_release(r);
     asl_free(q);
 
     return foundNewEntries;


### PR DESCRIPTION
Changes in this pull request:

- Fixes iOS 8 bug where landscape snapshot images would be stretched the wrong way (#39)
- Fixes `aslresponse_next` and `aslresponse_free` availability issues (and silences warnings) (#38)
- Fixes tint for navigation bar title
- Fixes `dismissAninmated:completion:` method name typo

Here's what would happen on iOS 8 in landscape:

![ios simulator screen shot may 25 2015 9 41 38 pm](https://cloud.githubusercontent.com/assets/1198851/7805448/71f7df00-0327-11e5-84a7-152723ffb6cb.png)

![ios simulator screen shot may 25 2015 9 41 36 pm](https://cloud.githubusercontent.com/assets/1198851/7805452/767aa40e-0327-11e5-83c6-ffaa18d113d8.png)
