### PR TITLE
Using presentation full screen of navigation controller

### DIFF
--- a/BugshotKit/BugshotKit.m
+++ b/BugshotKit/BugshotKit.m
@@ -425,6 +425,7 @@ UIImage *BSKImageWithDrawing(CGSize size, void (^drawingCommands)())
     self.presentedNavigationController = nc;
     nc.navigationBar.tintColor = BugshotKit.sharedManager.annotationFillColor;
     nc.navigationBar.titleTextAttributes = @{ NSForegroundColorAttributeName:BugshotKit.sharedManager.annotationFillColor };
+    nc.modalPresentationStyle = UIModalPresentationFullScreen;
     [presentingViewController presentViewController:nc animated:YES completion:NULL];
 }
 


### PR DESCRIPTION
This is to be able to draw arrows over screenshots.

After iOS 13, modal presentations can be dismissed by dragging down on the controller, this makes it impossible to draw arrows over the screenshots.

This PR makes the modal presentation full screen again to avoid this from happening.